### PR TITLE
Fix for /ctfortify timer

### DIFF
--- a/src/com/untamedears/citadel/listener/BlockListener.java
+++ b/src/com/untamedears/citadel/listener/BlockListener.java
@@ -56,6 +56,8 @@ public class BlockListener extends PluginConsumer implements Listener {
             if (createReinforcement(player, block) == null) {
                 sendMessage(player, ChatColor.RED, "%s is not a reinforcible material", block.getType().name());
             }
+            else
+            	state.checkResetMode();
         } else {
             sendMessage(player, ChatColor.YELLOW, "%s depleted, left fortification mode", material.getMaterial().name());
             state.reset();


### PR DESCRIPTION
This fix assures that the [20-second] mode reset timer starts over when a fortified block is placed.
