### PR TITLE
FIX for breaking reinforced snitch blocks.

### DIFF
--- a/src/com/untamedears/citadel/listener/BlockListener.java
+++ b/src/com/untamedears/citadel/listener/BlockListener.java
@@ -78,7 +78,7 @@ public class BlockListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOW)
     public void blockBreak(BlockBreakEvent bbe) {
         Block block = bbe.getBlock();
         Player player = bbe.getPlayer();


### PR DESCRIPTION
By setting the priority to LOW, Citadel's blockBreak event runs before PreciousStones and is able to cancel the break event before the snitch block record is removed.
