### PR TITLE
Adding chunk-wise RAM caching

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="C:/Users/Jonny/Desktop/Workspace/Minecraft/CraftBukkit/craftbukkit.jar">
+	<classpathentry kind="lib" path="craftbukkit.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="http://jd.bukkit.org/apidocs/"/>
 		</attributes>

--- a/bin/META-INF/MANIFEST.MF
+++ b/bin/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+

--- a/config.yml
+++ b/config.yml
@@ -52,3 +52,6 @@ database:
   isolation: SERIALIZABLE
   logging: false
   rebuild: false
+caching:
+  max_age: 300000
+  max_chunks: 10000

--- a/src/com/untamedears/citadel/Citadel.java
+++ b/src/com/untamedears/citadel/Citadel.java
@@ -41,6 +41,7 @@ import com.untamedears.citadel.command.commands.SecurableCommand;
 import com.untamedears.citadel.command.commands.StatsCommand;
 import com.untamedears.citadel.command.commands.TransferCommand;
 import com.untamedears.citadel.command.commands.VersionCommand;
+import com.untamedears.citadel.dao.CitadelCachingDao;
 import com.untamedears.citadel.dao.CitadelDao;
 import com.untamedears.citadel.entity.Faction;
 import com.untamedears.citadel.entity.FactionMember;
@@ -66,7 +67,7 @@ public class Citadel extends JavaPlugin {
     private static final PersonalGroupManager personalGroupManager = new PersonalGroupManager();
     private static final MemberManager memberManager = new MemberManager();
     private static final ConfigManager configManager = new ConfigManager();
-    private static CitadelDao dao;
+    private static CitadelCachingDao dao;
     private static Citadel plugin;
     
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args){
@@ -75,7 +76,7 @@ public class Citadel extends JavaPlugin {
 
     public void onEnable() {
         plugin = this;
-        dao = new CitadelDao(this);
+        dao = new CitadelCachingDao(this);
         dao.updateDatabase();
         setUpStorage();
         registerCommands();
@@ -95,6 +96,11 @@ public class Citadel extends JavaPlugin {
     }
 
     public void onDisable() {
+    	//There should be some interface that CitadelCachingDao can implement that does this automatically on disable:
+        //I don't want to do this as close() or finalize() because I want to make sure the database connection is still alive.
+    	if( dao instanceof CitadelCachingDao ){
+            ((CitadelCachingDao)dao).shutDown();
+        }
         log.info("[Citadel] Citadel is now disabled.");
     }
     

--- a/src/com/untamedears/citadel/ConfigManager.java
+++ b/src/com/untamedears/citadel/ConfigManager.java
@@ -20,6 +20,8 @@ public class ConfigManager {
 	private boolean verboseLogging;
 	private double redstoneDistance;
 	private int groupsAllowed;
+	private long cacheMaxAge;
+	private int cacheMaxChunks;
 
 	public void load(){
 		Citadel.getPlugin().reloadConfig();
@@ -30,6 +32,8 @@ public class ConfigManager {
         verboseLogging = config.getBoolean("general.verboseLogging");
         redstoneDistance = config.getDouble("general.redstoneDistance");
         groupsAllowed = config.getInt("general.groupsAllowed");
+        cacheMaxAge = config.getLong("caching.max_age");
+        cacheMaxChunks = config.getInt("caching.max_chunks");
         for (Object obj : config.getList("materials")) {
             LinkedHashMap map = (LinkedHashMap) obj;
             ReinforcementMaterial.put(new ReinforcementMaterial(map));
@@ -70,5 +74,13 @@ public class ConfigManager {
 	
 	public boolean getVerboseLogging(){
 		return this.verboseLogging;
+	}
+	
+	public long getCacheMaxAge(){
+		return this.cacheMaxAge;
+	}
+	
+	public int getCacheMaxChunks(){
+		return this.cacheMaxChunks;
 	}
 }

--- a/src/com/untamedears/citadel/dao/CitadelCachingDao.java
+++ b/src/com/untamedears/citadel/dao/CitadelCachingDao.java
@@ -1,0 +1,181 @@
+package com.untamedears.citadel.dao;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import com.untamedears.citadel.Citadel;
+import com.untamedears.citadel.entity.Reinforcement;
+import com.untamedears.citadel.entity.ReinforcementKey;
+
+public class CitadelCachingDao extends CitadelDao{
+	HashMap<Chunk, ChunkCache> cachesByChunk;
+	LinkedList<ChunkCache> cachesByTime;
+
+	long maxAge;
+	int maxChunks;
+	
+	public CitadelCachingDao(JavaPlugin plugin){
+		super(plugin);
+		maxAge = Citadel.getConfigManager().getCacheMaxAge();
+		maxChunks = Citadel.getConfigManager().getCacheMaxChunks();
+	}
+	
+	public ChunkCache getCacheOfBlock( Block block ) throws RefuseToPreventThrashingException {
+		ChunkCache cache = cachesByChunk.get( block.getChunk() );
+		if( cache != null ){
+			cachesByTime.remove(cache);
+			cachesByTime.add(cache);
+		}else{
+			if( cachesByTime.size() > maxChunks ){
+				throw new RefuseToPreventThrashingException();
+			}
+			cache = new ChunkCache( block.getChunk() );
+			cachesByChunk.put( block.getChunk() , cache );
+			cachesByTime.add( cache );
+			
+			ChunkCache last = cachesByTime.getLast();
+			while( last.getLastPlooked() + maxAge < System.currentTimeMillis() ||
+				   cachesByTime.size() > maxChunks ){
+				last.flush();
+				cachesByTime.remove(last);
+				cachesByChunk.remove(last.getChunk());
+			}
+		}
+		return cache;
+	}
+	
+	@Override
+	public Reinforcement findReinforcement( Location location ){
+		return findReinforcement(location.getBlock());
+	}
+	
+	@Override
+	public Reinforcement findReinforcement( Block block ){
+		try{
+			ChunkCache cache = getCacheOfBlock( block );
+			return cache.findReinforcement(block);
+		}catch( RefuseToPreventThrashingException e ){
+			Citadel.warning( "Bypassing RAM cache to prevent database thrashing.  Consider raising caching.max_chunks");
+			return super.findReinforcement( block );
+		}
+	}
+	
+	@Override
+	public void save(Object o){
+		if( o instanceof Reinforcement ){
+			Reinforcement r = (Reinforcement)o;
+			try{
+				getCacheOfBlock( r.getBlock() ).save( r );
+			}catch( RefuseToPreventThrashingException e ){
+				Citadel.warning( "Bypassing RAM cache to prevent database thrashing.  Consider raising caching.max_chunks");
+				super.save( r );
+			}
+		}else{
+			super.save( o );
+		}
+	}
+	
+	@Override
+	public void delete(Object o){
+		if( o instanceof Reinforcement ){
+			Reinforcement r = (Reinforcement)o;
+			try{
+				getCacheOfBlock( r.getBlock() ).save( r );
+			}catch( RefuseToPreventThrashingException e ){
+				Citadel.warning( "Bypassing RAM cache to prevent database thrashing.  Consider raising caching.max_chunks");
+				super.delete( r );
+			}
+		}else{
+			super.delete( o );
+		}
+	}
+	
+	//There should be some interface to implement that calls this automatically.
+	public void shutDown(){
+		while( !cachesByTime.isEmpty() ){
+			cachesByTime.pop().flush();
+		}
+	}
+	
+	private class ChunkCache {
+		TreeSet<Reinforcement> toSave;//if RAM isn't a problem replace this with a HashSet.
+		TreeSet<Reinforcement> toDelete;//if RAM isn't a problem replace this with a HashSet.
+		
+		TreeSet<Reinforcement> cache;//if RAM isn't a problem replace this with a HashSet.
+		
+		Chunk chunk;
+		long lastPlooked;
+		
+		public ChunkCache( Chunk chunk ){
+			this.chunk = chunk;
+			cache = new TreeSet<Reinforcement>( findReinforcementsInChunk( chunk ));
+		}
+		
+		public Reinforcement findReinforcement( Location l ){
+			return findReinforcement(l.getBlock());
+		}
+		
+		public Reinforcement findReinforcement( Block block ){
+			lastPlooked = System.currentTimeMillis();
+			
+			Reinforcement key = new Reinforcement();
+			key.setId(new ReinforcementKey(block));
+			Reinforcement r = cache.floor( key );
+			
+			if( r.equals(key) ){
+				toSave.add(r);
+				return r;
+			}else{
+				return null;
+			}
+		}
+		
+		public void save( Reinforcement r ){
+			lastPlooked = System.currentTimeMillis();
+			if( !cache.add( r )){
+				//Yes, this makes sense.
+				//If we're editing the cache, then our new "r" will equal the old "r"
+				//because reinforements are compared by their ReinforcementKeys, and the
+				//new and old Reinforcements have the same key.  So we're removing the reinforcement
+				//from the set that matches the new "r" (which the old "r" does) and then adding
+				//the new "r".
+				cache.remove( r );
+				cache.add( r );
+			}
+			toDelete.remove( r );
+			toSave.add( r );
+		}
+		
+		public void delete( Reinforcement r ){
+			lastPlooked = System.currentTimeMillis();
+			cache.remove( r );
+			toSave.remove( r );
+			toDelete.add( r );
+		}
+		
+		public void flush(){
+			getDatabase().save(toSave);
+			getDatabase().delete(toDelete);
+		}
+		
+		public long getLastPlooked(){
+			return lastPlooked;
+		}
+		
+		public Chunk getChunk(){
+			return chunk;
+		}
+	}
+	
+	private class RefuseToPreventThrashingException extends Exception{
+		
+	}
+}

--- a/src/com/untamedears/citadel/dao/CitadelDao.java
+++ b/src/com/untamedears/citadel/dao/CitadelDao.java
@@ -1,11 +1,13 @@
 package com.untamedears.citadel.dao;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
 import javax.persistence.PersistenceException;
 
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.Configuration;
@@ -32,6 +34,7 @@ import com.untamedears.citadel.entity.ReinforcementKey;
  * 7/18/12
  */
 public class CitadelDao extends MyDatabase {
+	private static final int CHUNK_SIZE = 16;
 
     public CitadelDao(JavaPlugin plugin) {
         super(plugin);
@@ -158,6 +161,18 @@ public class CitadelDao extends MyDatabase {
                 .findUnique();
     }
     
+    public Set<Reinforcement> findReinforcementsInChunk(Chunk c){
+    	//The minus ones are intentional.  Think about fenceposts if you aren't sure why.
+    	return getDatabase().createQuery(Reinforcement.class, "find reinforcement where x >= :xlo and x <= :xhi " +
+    			"and z >= :zlo and z <= :zhi and world = :world").
+    			setParameter("xlo", c.getX()).
+    			setParameter("xhi", c.getX()+CHUNK_SIZE-1).
+    			setParameter("zlo", c.getZ()).
+    			setParameter("zhi", c.getZ()+CHUNK_SIZE-1).
+    			setParameter("world", c.getWorld().getName()).
+    			findSet();
+    }
+    
     public void moveReinforcements(String from, String target){
     	SqlUpdate update = getDatabase().createSqlUpdate("UPDATE reinforcement SET name = :target, security_level = 1" +
     			" WHERE name = :from")
@@ -197,16 +212,6 @@ public class CitadelDao extends MyDatabase {
 	public Set<PersonalGroup> findAllPersonalGroups() {
 		return getDatabase().createQuery(PersonalGroup.class, "find personalGroup")
 				.findSet();
-	}
-
-	public void addRein(int x, int y, int z, String groupName) {
-		SqlUpdate update = getDatabase().createSqlUpdate("INSERT INTO reinforcement (x, y, z, world, material_id, durability, security_level, name)" +
-				"Values (:x, :y, :z, 'World One', 1, 1800, 1, :groupName)")
-				.setParameter("x", x)
-				.setParameter("y", y)
-				.setParameter("z", z)
-				.setParameter("groupName", groupName);
-		getDatabase().execute(update);
 	}
 
 	public void addGroup(String groupName) {

--- a/src/com/untamedears/citadel/entity/Reinforcement.java
+++ b/src/com/untamedears/citadel/entity/Reinforcement.java
@@ -21,7 +21,7 @@ import com.untamedears.citadel.SecurityLevel;
  * User: chrisrico
  */
 @Entity
-public class Reinforcement {
+public class Reinforcement implements Comparable<Reinforcement> {
 
     public static final List<Integer> SECURABLE = new ArrayList<Integer>();
     public static final List<Integer> NON_REINFORCEABLE = new ArrayList<Integer>();
@@ -180,6 +180,10 @@ public class Reinforcement {
         Reinforcement rein = (Reinforcement) o;
 
         return this.id.equals(rein.id);
+    }
+    
+    public int compareTo( Reinforcement r ){
+    	return this.id.compareTo( r.id );
     }
 
     @Override

--- a/src/com/untamedears/citadel/entity/ReinforcementKey.java
+++ b/src/com/untamedears/citadel/entity/ReinforcementKey.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 import javax.persistence.Embeddable;
 
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 
 /**
@@ -14,7 +15,7 @@ import org.bukkit.block.Block;
  */
 
 @Embeddable
-public class ReinforcementKey implements Serializable {
+public class ReinforcementKey implements Serializable, Comparable<ReinforcementKey> {
     private static final long serialVersionUID = 8057222586259248268L;
 
     private int x;
@@ -72,6 +73,32 @@ public class ReinforcementKey implements Serializable {
         ReinforcementKey key = (ReinforcementKey) o;
 
         return x == key.x && y == key.y && z == key.z && world.equals(key.world);
+    }
+    
+    /**
+     * Order keys in lexographic order.
+     * 
+     * @param rk2
+     * @return
+     */
+    public int compareTo(ReinforcementKey rk2) {
+    	ReinforcementKey rk1 = this;
+    	
+    	if( rk1.x < rk2.x ){
+    		return -1;
+    	}else if( rk1.x > rk2.x ){
+    		return 1;
+    	}else if( rk1.y < rk2.y ){
+    		return -1;
+    	}else if( rk1.y > rk2.y ){
+    		return 1;
+    	}else if( rk1.z < rk2.z ){
+    		return -1;
+    	}else if( rk1.z > rk2.z ){
+    		return 1;
+    	}else{
+    		return rk1.world.compareTo(rk2.world);
+    	}
     }
 
     @Override


### PR DESCRIPTION
RAM caching is added by extending CitadelDao.  When the plugin wants to
query the database about a block, CitadelCachingDao transparantly loads
all the reinforcement data in the same chunk as that block into the RAM,
if it's not cached already.  If changes are made to reinforcements on a
cached chunk, those changes are consolidated in ram so there'll only be
hd read/write when chunks are loaded/unloaded from the RAM cache.  When
new chunks are loaded into RAM, all chunks older than an age given in
the config are released (and therefore flushed).  There's a hard limit
to the amount of chunks that can be held in RAM (to make
resource-wasting griefing impossible) and when that limit is met, the
entire cache is bypassed (to prevent thrashing).

Right now this is completely untested, I haven't set up MySQL yet.

Also, the craftbukkit library is now local and included relatively for
ease of development.
