### PR TITLE
Removed infinite diamond exploit

### DIFF
--- a/src/com/untamedears/citadel/dao/CitadelCachingDao.java
+++ b/src/com/untamedears/citadel/dao/CitadelCachingDao.java
@@ -95,7 +95,7 @@ public class CitadelCachingDao extends CitadelDao{
         if( o instanceof Reinforcement ){
             Reinforcement r = (Reinforcement)o;
             try{
-                getCacheOfBlock( r.getBlock() ).save( r );
+                getCacheOfBlock( r.getBlock() ).delete( r );
             }catch( RefuseToPreventThrashingException e ){
                 Citadel.warning( "Bypassing RAM cache to prevent database thrashing.  Consider raising caching.max_chunks");
                 super.delete( r );


### PR DESCRIPTION
Typo prevented removed reinforcements from actually being removed,
allowing players to harvest infinite diamond with a sand glitch.  That's
removed now and chunks caches now accurately remove reinforcements.
