### PR TITLE
Issue#71 Naturally reinforced blocks

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -44,6 +44,9 @@ nonReinforceable:
 - VINE
 - NETHER_WARTS
 - ENDER_PORTAL
+hardenedMaterials:
+  IRON_ORE: 3
+  DIAMOND_ORE: 10
 database:
   driver: com.mysql.jdbc.Driver
   url: jdbc:mysql://localhost:3306/bukkit

--- a/src/com/untamedears/citadel/ConfigManager.java
+++ b/src/com/untamedears/citadel/ConfigManager.java
@@ -36,18 +36,26 @@ public class ConfigManager {
         }
         for (String name : config.getStringList("additionalSecurable")) {
             Material material = Material.matchMaterial(name);
-            if (material == null) {
-                Citadel.warning("Invalid additionalSecurable material " + name);
+            if (material != null) {
+            	Reinforcement.SECURABLE.add(material.getId());
             } else {
-                Reinforcement.SECURABLE.add(material.getId());
+            	try {
+            		Reinforcement.SECURABLE.add(Integer.parseInt(name));
+            	} catch (NumberFormatException e) {
+            		Citadel.warning("Invalid additionalSecurable material " + name);
+            	}
             }
         }
         for (String name : config.getStringList("nonReinforceable")) {
-            Material material = Material.matchMaterial(name);
-            if (material == null) {
-                Citadel.warning("Invalid nonReinforceable material " + name);
+        	Material material = Material.matchMaterial(name);
+            if (material != null) {
+            	Reinforcement.NON_REINFORCEABLE.add(material.getId());
             } else {
-                Reinforcement.NON_REINFORCEABLE.add(material.getId());
+            	try {
+            		Reinforcement.NON_REINFORCEABLE.add(Integer.parseInt(name));
+            	} catch (NumberFormatException e) {
+            		Citadel.warning("Invalid nonReinforceable material " + name);
+            	}
             }
         }
 	}

--- a/src/com/untamedears/citadel/ConfigManager.java
+++ b/src/com/untamedears/citadel/ConfigManager.java
@@ -3,6 +3,7 @@ package com.untamedears.citadel;
 import java.util.LinkedHashMap;
 
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import com.untamedears.citadel.entity.Reinforcement;
@@ -54,6 +55,22 @@ public class ConfigManager {
                 Reinforcement.NON_REINFORCEABLE.add(material.getId());
             }
         }
+	ConfigurationSection hardenedMaterials = config.getConfigurationSection("hardenedMaterials");
+	for (String materialName : hardenedMaterials.getKeys(false)) {
+            Material material = Material.matchMaterial(materialName);
+            if (material == null) {
+                Citadel.warning("Invalid hardenedMaterials material " + materialName);
+            } else {
+		int breakCount = hardenedMaterials.getInt(materialName);
+		// .1 sec * 100 == 10 sec max to break the quickest blocks seems reasonable.
+		if (breakCount < 2 || breakCount > 100) {
+                    Citadel.warning("Invalid hardenedMaterials breakCount " +
+				    materialName + " " + Integer.toString(breakCount));
+		} else {
+                    Reinforcement.HARDENED_BREAK_COUNTS.put(material.getId(), breakCount);
+		}
+            }
+	}
 	}
 	
 	public double getRedstoneDistance(){
@@ -82,5 +99,13 @@ public class ConfigManager {
 	
 	public int getCacheMaxChunks(){
 		return this.cacheMaxChunks;
+	}
+
+	public int getMaterialBreakCount(int materialId){
+		Integer breakCount = Reinforcement.HARDENED_BREAK_COUNTS.get(materialId);
+		if (breakCount == null) {
+			return 1;
+		}
+		return (int)breakCount;
 	}
 }

--- a/src/com/untamedears/citadel/ConfigManager.java
+++ b/src/com/untamedears/citadel/ConfigManager.java
@@ -65,17 +65,25 @@ public class ConfigManager {
         }
 	ConfigurationSection hardenedMaterials = config.getConfigurationSection("hardenedMaterials");
 	for (String materialName : hardenedMaterials.getKeys(false)) {
+	    int materialId = Integer.MIN_VALUE;
             Material material = Material.matchMaterial(materialName);
-            if (material == null) {
-                Citadel.warning("Invalid hardenedMaterials material " + materialName);
-            } else {
+	    if (material != null) {
+	        materialId = material.getId();
+	    } else {
+	        try {
+		    materialId = Integer.parseInt(materialName);
+		} catch (NumberFormatException e) {
+                    Citadel.warning("Invalid hardenedMaterials material " + materialName);
+		}
+	    }
+	    if (materialId != Integer.MIN_VALUE) {
 		int breakCount = hardenedMaterials.getInt(materialName);
-		// .1 sec * 100 == 10 sec max to break the quickest blocks seems reasonable.
-		if (breakCount < 2 || breakCount > 100) {
+		// .1 sec * 600 == 60 sec max to break the quickest blocks seems reasonable.
+		if (breakCount < 2 || breakCount > 600) {
                     Citadel.warning("Invalid hardenedMaterials breakCount " +
 				    materialName + " " + Integer.toString(breakCount));
 		} else {
-                    Reinforcement.HARDENED_BREAK_COUNTS.put(material.getId(), breakCount);
+                    Reinforcement.HARDENED_BREAK_COUNTS.put(materialId, breakCount);
 		}
             }
 	}

--- a/src/com/untamedears/citadel/SecurityLevel.java
+++ b/src/com/untamedears/citadel/SecurityLevel.java
@@ -14,5 +14,8 @@ public enum SecurityLevel {
     @EnumValue("1")
     PRIVATE,
     @EnumValue("2")
-    GROUP
+    GROUP,
+    // Used when auto-generating a reinforcement in the world
+    @EnumValue("3")
+    GENERATED
 }

--- a/src/com/untamedears/citadel/Utility.java
+++ b/src/com/untamedears/citadel/Utility.java
@@ -141,9 +141,13 @@ public class Utility {
         Citadel.info("Reinforcement %s destroyed at " + reinforcement.getBlock().getLocation().toString());
 
         Citadel.getReinforcementManager().removeReinforcement(reinforcement);
+	if (reinforcement.getSecurityLevel() == SecurityLevel.GENERATED) {
+		return false;
+	}
         if (rng.nextDouble() <= reinforcement.getHealth()) {
             Location location = reinforcement.getBlock().getLocation();
-            location.getWorld().dropItem(location, reinforcement.getMaterial().getRequiredMaterials());
+	    ReinforcementMaterial material = reinforcement.getMaterial();
+            location.getWorld().dropItem(location, material.getRequiredMaterials());
         }
         return reinforcement.isSecurable();
     }

--- a/src/com/untamedears/citadel/command/CommandHandler.java
+++ b/src/com/untamedears/citadel/command/CommandHandler.java
@@ -61,9 +61,9 @@ public class CommandHandler {
 	}
 	
 	private void displayCommandHelp(Command cmd, CommandSender sender){
-		sender.sendMessage(new StringBuilder().append("§cCommand:§e " ).append(cmd.getName()).toString());
-		sender.sendMessage(new StringBuilder().append("§cDescription:§e " ).append(cmd.getDescription()).toString());
-		sender.sendMessage(new StringBuilder().append("§cUsage:§e ").append(cmd.getUsage()).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cCommand:Â§e " ).append(cmd.getName()).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cDescription:Â§e " ).append(cmd.getDescription()).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cUsage:Â§e ").append(cmd.getUsage()).toString());
 	}
 
 	private Command getCmdFromIdent(String ident, CommandSender executor) {

--- a/src/com/untamedears/citadel/command/commands/AddModCommand.java
+++ b/src/com/untamedears/citadel/command/commands/AddModCommand.java
@@ -23,7 +23,7 @@ public class AddModCommand extends PlayerCommand {
 	public AddModCommand() {
 		super("Add Moderator");
 		setDescription("Adds a player as moderator to a group");
-		setUsage("/ctaddmod ง8<group-name> <player-name>");
+		setUsage("/ctaddmod ยง8<group-name> <player-name>");
 		setArgumentRange(2,2);
 		setIdentifiers(new String[] {"ctaddmod", "ctam"});
 	}

--- a/src/com/untamedears/citadel/command/commands/AllowCommand.java
+++ b/src/com/untamedears/citadel/command/commands/AllowCommand.java
@@ -23,7 +23,7 @@ public class AllowCommand extends PlayerCommand {
 	public AllowCommand() {
 		super("Allow Player");
 		setDescription("Adds a player to your group");
-		setUsage("/ctallow ง8<group-name> <player name>");
+		setUsage("/ctallow ยง8<group-name> <player name>");
 		setArgumentRange(2,2);
 		setIdentifiers(new String[] {"ctallow", "cta"});
 	}

--- a/src/com/untamedears/citadel/command/commands/CreateCommand.java
+++ b/src/com/untamedears/citadel/command/commands/CreateCommand.java
@@ -20,7 +20,7 @@ public class CreateCommand extends PlayerCommand {
 	public CreateCommand(){
 		super("Create Group");
 		setDescription("Creates a new group");
-		setUsage("/ctcreate ง8<group-name>");
+		setUsage("/ctcreate ยง8<group-name>");
 		setArgumentRange(1, 1);
 		setIdentifiers(new String[] {"ctcreate", "ctc"});
 	}

--- a/src/com/untamedears/citadel/command/commands/DeleteCommand.java
+++ b/src/com/untamedears/citadel/command/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand extends PlayerCommand {
 	public DeleteCommand() {
 		super("Delete group");
 		setDescription("Deletes a group");
-		setUsage("/ctdelete ง8<group-name>");
+		setUsage("/ctdelete ยง8<group-name>");
 		setArgumentRange(1,1);
 		setIdentifiers(new String[] {"ctdelete", "ctdel"});
 	}

--- a/src/com/untamedears/citadel/command/commands/DisallowCommand.java
+++ b/src/com/untamedears/citadel/command/commands/DisallowCommand.java
@@ -20,7 +20,7 @@ public class DisallowCommand extends PlayerCommand {
 	public DisallowCommand() {
 		super("Disallow Player");
 		setDescription("Removes a player from a group");
-		setUsage("/ctdisallow ง8<group-name> <player-name>");
+		setUsage("/ctdisallow ยง8<group-name> <player-name>");
 		setArgumentRange(2,2);
 		setIdentifiers(new String[] {"ctdisallow", "ctd"});
 	}

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -27,7 +27,7 @@ public class FortifyCommand extends PlayerCommand {
 	public FortifyCommand() {
 		super("Fority Mode");
 		setDescription("Toggle fortification mode");
-		setUsage("/ctfortify §8[security-level]");
+		setUsage("/ctfortify Â§8[security-level]");
 		setArgumentRange(0, 2);
 		setIdentifiers(new String[] {"ctfortify", "ctf"});
 	}
@@ -46,8 +46,8 @@ public class FortifyCommand extends PlayerCommand {
 		}
 		if(secLevel != null && secLevel.equalsIgnoreCase("group")){
 			if(groupName == null || groupName.isEmpty() || groupName.equals("")){
-				sender.sendMessage(new StringBuilder().append("§cYou must specify a group in group fortification mode").toString());
-				sender.sendMessage(new StringBuilder().append("§cUsage:§e ").append("/ctfortify §8group <group-name>").toString());
+				sender.sendMessage(new StringBuilder().append("Â§cYou must specify a group in group fortification mode").toString());
+				sender.sendMessage(new StringBuilder().append("Â§cUsage:Â§e ").append("/ctfortify Â§8group <group-name>").toString());
 				return true;
 			}
 			GroupManager groupManager = Citadel.getGroupManager();

--- a/src/com/untamedears/citadel/command/commands/GroupCommand.java
+++ b/src/com/untamedears/citadel/command/commands/GroupCommand.java
@@ -23,7 +23,7 @@ public class GroupCommand extends PlayerCommand {
 	public GroupCommand() {
 		super("Group Mode");
 		setDescription("Toggle group mode");
-		setUsage("/ctgroup ง8<group-name>");
+		setUsage("/ctgroup ยง8<group-name>");
 		setArgumentRange(1,1);
 		setIdentifiers(new String[] {"ctgroup", "ctg"});
 	}

--- a/src/com/untamedears/citadel/command/commands/GroupInfoCommand.java
+++ b/src/com/untamedears/citadel/command/commands/GroupInfoCommand.java
@@ -15,7 +15,7 @@ public class GroupInfoCommand extends PlayerCommand {
 	public GroupInfoCommand() {
 		super("Group Information");
 		setDescription("Displays information about a group");
-		setUsage("/ctgroupinfo §8<group-name>");
+		setUsage("/ctgroupinfo Â§8<group-name>");
 		setArgumentRange(1,1);
 		setIdentifiers(new String[] {"ctgroupinfo", "ctgi"});
 	}
@@ -33,20 +33,20 @@ public class GroupInfoCommand extends PlayerCommand {
 			sendMessage(sender, ChatColor.RED, "Invalid permission to access this group");
 			return true;
 		}
-		sender.sendMessage(new StringBuilder().append("§cGroup Name:§e ").append(groupName).toString());
-		sender.sendMessage(new StringBuilder().append("§cOwner:§e ").append(group.getFounder()).toString());
-		sender.sendMessage(new StringBuilder().append("§cModerators:§e ").append(groupManager.getModeratorsOfGroup(groupName).size()).toString());
-		sender.sendMessage(new StringBuilder().append("§cMembers:§e ").append(groupManager.getMembersOfGroup(groupName).size()).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cGroup Name:Â§e ").append(groupName).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cOwner:Â§e ").append(group.getFounder()).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cModerators:Â§e ").append(groupManager.getModeratorsOfGroup(groupName).size()).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cMembers:Â§e ").append(groupManager.getMembersOfGroup(groupName).size()).toString());
 		if(group.isFounder(senderName) || group.isModerator(senderName)){
 			String password = group.getPassword();
-			sender.sendMessage(new StringBuilder().append("§cPassword:§e ").append(password).toString());
+			sender.sendMessage(new StringBuilder().append("Â§cPassword:Â§e ").append(password).toString());
 			String joinable = "";
 			if(password != null && !password.equalsIgnoreCase("null")){
 				joinable = "Yes";
 			} else {
 				joinable = "No";
 			}
-			sender.sendMessage(new StringBuilder().append("§cJoinable:§e ").append(joinable).toString());
+			sender.sendMessage(new StringBuilder().append("Â§cJoinable:Â§e ").append(joinable).toString());
 		}
 		return true;
 	}

--- a/src/com/untamedears/citadel/command/commands/JoinCommand.java
+++ b/src/com/untamedears/citadel/command/commands/JoinCommand.java
@@ -21,7 +21,7 @@ public class JoinCommand extends PlayerCommand {
 	public JoinCommand() {
 		super("Join Group");
         setDescription("Joins a group");
-        setUsage("/ctjoin ง8<group-name> <password>");
+        setUsage("/ctjoin ยง8<group-name> <password>");
         setArgumentRange(2,2);
 		setIdentifiers(new String[] {"ctjoin", "ctj"});
 	}

--- a/src/com/untamedears/citadel/command/commands/LeaveCommand.java
+++ b/src/com/untamedears/citadel/command/commands/LeaveCommand.java
@@ -22,7 +22,7 @@ public class LeaveCommand extends PlayerCommand {
 	public LeaveCommand() {
 		super("Leave");
         setDescription("Leave a group");
-        setUsage("/ctleave ง8<group-name>");
+        setUsage("/ctleave ยง8<group-name>");
         setArgumentRange(1,1);
 		setIdentifiers(new String[] {"ctleave", "ctl"});
 	}

--- a/src/com/untamedears/citadel/command/commands/MembersCommand.java
+++ b/src/com/untamedears/citadel/command/commands/MembersCommand.java
@@ -28,7 +28,7 @@ public class MembersCommand extends PlayerCommand {
 	public MembersCommand() {
 		super("List Members");
 		setDescription("List the members of a group");
-		setUsage("/ctmembers ง8<group-name>");
+		setUsage("/ctmembers ยง8<group-name>");
 		setArgumentRange(1,1);
 		setIdentifiers(new String[] {"ctmembers", "ctm"});
 	}

--- a/src/com/untamedears/citadel/command/commands/ModeratorsCommand.java
+++ b/src/com/untamedears/citadel/command/commands/ModeratorsCommand.java
@@ -24,7 +24,7 @@ public class ModeratorsCommand extends PlayerCommand {
 	public ModeratorsCommand() {
 		super("List Moderators");
 		setDescription("List the moderators of a group");
-		setUsage("/ctmoderators ง8<group-name>");
+		setUsage("/ctmoderators ยง8<group-name>");
 		setArgumentRange(1,1);
 		setIdentifiers(new String[] {"ctmoderators", "ctmods"});
 	}

--- a/src/com/untamedears/citadel/command/commands/PasswordCommand.java
+++ b/src/com/untamedears/citadel/command/commands/PasswordCommand.java
@@ -20,7 +20,7 @@ public class PasswordCommand extends PlayerCommand {
 	public PasswordCommand() {
 		super("Set Group Password");
         setDescription("Sets the password for a group. Set password to \"null\" to make your group not joinable");
-        setUsage("/ctpassword ง8<group-name> <password>");
+        setUsage("/ctpassword ยง8<group-name> <password>");
         setArgumentRange(2,2);
 		setIdentifiers(new String[] {"ctpassword", "ctpw"});
 	}

--- a/src/com/untamedears/citadel/command/commands/ReinforceCommand.java
+++ b/src/com/untamedears/citadel/command/commands/ReinforceCommand.java
@@ -26,7 +26,7 @@ public class ReinforceCommand extends PlayerCommand {
 	public ReinforceCommand() {
 		super("Reinforce Mode");
 		setDescription("Toggles reinforce mode");
-		setUsage("/ctreinforce §8[security-level] [group-name]");
+		setUsage("/ctreinforce Â§8[security-level] [group-name]");
 		setArgumentRange(0, 2);
 		setIdentifiers(new String[] {"ctreinforce", "ctr"});
 	}
@@ -45,8 +45,8 @@ public class ReinforceCommand extends PlayerCommand {
 		}
 		if(secLevel != null && secLevel.equalsIgnoreCase("group")){
 			if(groupName == null || groupName.isEmpty() || groupName.equals("")){
-				sender.sendMessage(new StringBuilder().append("§cYou must specify a group in group reinforce mode").toString());
-				sender.sendMessage(new StringBuilder().append("§cUsage:§e ").append("/ctreinforce §8group <group-name>").toString());
+				sender.sendMessage(new StringBuilder().append("Â§cYou must specify a group in group reinforce mode").toString());
+				sender.sendMessage(new StringBuilder().append("Â§cUsage:Â§e ").append("/ctreinforce Â§8group <group-name>").toString());
 				return true;
 			}
 			GroupManager groupManager = Citadel.getGroupManager();

--- a/src/com/untamedears/citadel/command/commands/RemoveModCommand.java
+++ b/src/com/untamedears/citadel/command/commands/RemoveModCommand.java
@@ -20,7 +20,7 @@ public class RemoveModCommand extends PlayerCommand {
 	public RemoveModCommand() {
 		super("Remove Moderator");
 		setDescription("Removes a player as moderator from a group");
-		setUsage("/ctremovemod ง8<group-name> <player-name>");
+		setUsage("/ctremovemod ยง8<group-name> <player-name>");
 		setArgumentRange(2,2);
 		setIdentifiers(new String[] {"ctremovemod", "ctrm"});
 	}

--- a/src/com/untamedears/citadel/command/commands/StatsCommand.java
+++ b/src/com/untamedears/citadel/command/commands/StatsCommand.java
@@ -28,8 +28,8 @@ public class StatsCommand extends PlayerCommand {
 		GroupManager groupManager = Citadel.getGroupManager();
 		int numGroups = groupManager.getGroupsAmount();
 		
-		sender.sendMessage(new StringBuilder().append("§cTotal Reinforcements:§e " ).append(numReinforcements).toString());
-		sender.sendMessage(new StringBuilder().append("§cTotal Groups:§e " ).append(numGroups).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cTotal Reinforcements:Â§e " ).append(numReinforcements).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cTotal Groups:Â§e " ).append(numGroups).toString());
 		return true;
 	}
 

--- a/src/com/untamedears/citadel/command/commands/TransferCommand.java
+++ b/src/com/untamedears/citadel/command/commands/TransferCommand.java
@@ -22,7 +22,7 @@ public class TransferCommand extends PlayerCommand {
 	public TransferCommand() {
 		super("Transfer Group");
 		setDescription("Transfers a group to another player. WARNING: You lose reinforcements associated with this group. This cannot be undone.");
-		setUsage("/cttransfer ง8<group-name> <player-name>");
+		setUsage("/cttransfer ยง8<group-name> <player-name>");
 		setArgumentRange(2, 2);
 		setIdentifiers(new String[] {"cttransfer", "ctt"});
 	}

--- a/src/com/untamedears/citadel/command/commands/VersionCommand.java
+++ b/src/com/untamedears/citadel/command/commands/VersionCommand.java
@@ -21,7 +21,7 @@ public class VersionCommand extends PlayerCommand {
 
 	public boolean execute(CommandSender sender, String[] args) {
 		String version = Citadel.getPlugin().getDescription().getVersion();
-		sender.sendMessage(new StringBuilder().append("§cCitadel Version:§e " ).append(version).toString());
+		sender.sendMessage(new StringBuilder().append("Â§cCitadel Version:Â§e " ).append(version).toString());
 		return true;
 	}
 

--- a/src/com/untamedears/citadel/dao/CitadelCachingDao.java
+++ b/src/com/untamedears/citadel/dao/CitadelCachingDao.java
@@ -12,6 +12,7 @@ import org.bukkit.block.Block;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import com.untamedears.citadel.Citadel;
+import com.untamedears.citadel.SecurityLevel;
 import com.untamedears.citadel.entity.Reinforcement;
 import com.untamedears.citadel.entity.ReinforcementKey;
 
@@ -141,7 +142,9 @@ public class CitadelCachingDao extends CitadelDao{
             Reinforcement r = cache.floor( key );
             
             if( r != null && r.equals(key) ){
-                toSave.add(r);
+	        if (r.getSecurityLevel() != SecurityLevel.GENERATED){
+                    toSave.add(r);
+	        }
                 return r;
             }else{
                 return null;
@@ -175,10 +178,10 @@ public class CitadelCachingDao extends CitadelDao{
             toDelete.remove( r );
             if (toSave.contains(r)){
                 toSave.remove(r);
-                toSave.add( r );
-            }else{
+	    }
+	    if (r.getSecurityLevel() != SecurityLevel.GENERATED){
                 toSave.add(r);
-            }
+	    }
         }
         
         public void delete( Reinforcement r ){

--- a/src/com/untamedears/citadel/entity/Reinforcement.java
+++ b/src/com/untamedears/citadel/entity/Reinforcement.java
@@ -1,6 +1,7 @@
 package com.untamedears.citadel.entity;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import javax.persistence.Entity;
@@ -25,10 +26,12 @@ public class Reinforcement implements Comparable<Reinforcement> {
 
     public static final List<Integer> SECURABLE = new ArrayList<Integer>();
     public static final List<Integer> NON_REINFORCEABLE = new ArrayList<Integer>();
+    // HashMap<materialId, breakCount>
+    public static final HashMap<Integer, Integer> HARDENED_BREAK_COUNTS = new HashMap<Integer, Integer>();
 
     @Id private ReinforcementKey id;
 
-    private int materialId;
+    private Integer materialId;
     private int durability;
     private SecurityLevel securityLevel;
 
@@ -45,6 +48,14 @@ public class Reinforcement implements Comparable<Reinforcement> {
         this.durability = material.getStrength();
         this.owner = owner;
         this.securityLevel = securityLevel;
+    }
+
+    public Reinforcement(Block block, int breakCount) {
+        this.id = new ReinforcementKey(block);
+        this.materialId = null;
+        this.durability = breakCount;
+        this.owner = null;
+        this.securityLevel = SecurityLevel.GENERATED;
     }
 
     public ReinforcementKey getId() {
@@ -66,10 +77,13 @@ public class Reinforcement implements Comparable<Reinforcement> {
     }
 
     public ReinforcementMaterial getMaterial() {
+	if (materialId == null) {
+		return null;
+ 	}
         return ReinforcementMaterial.get(Material.getMaterial(materialId));
     }
     
-    public int getMaterialId() {
+    public Integer getMaterialId() {
         return materialId;
     }
     
@@ -144,6 +158,8 @@ public class Reinforcement implements Comparable<Reinforcement> {
                 return name.equals(owner.getFounder()) || owner.isMember(name) || owner.isModerator(name);
             case PUBLIC:
             	return true;
+	    case GENERATED:
+		return false;
         }
         return false;
     }
@@ -153,6 +169,8 @@ public class Reinforcement implements Comparable<Reinforcement> {
         switch (securityLevel) {
             case PRIVATE:
                 return name.equals(owner.getFounder());
+	    case GENERATED:
+		return false;
             default:
                 return name.equals(owner.getFounder()) || owner.isModerator(name);
         }

--- a/src/com/untamedears/citadel/entity/ReinforcementMaterial.java
+++ b/src/com/untamedears/citadel/entity/ReinforcementMaterial.java
@@ -38,24 +38,37 @@ public class ReinforcementMaterial implements Comparable<ReinforcementMaterial> 
     
     public ReinforcementMaterial(LinkedHashMap map) {
         // Materials may be specified by name or by integer value
-    	Material material = Material.getMaterial(map.get("name").toString());
+    	Material material;
+    	
+    	material = Material.matchMaterial(map.get("name").toString());
         if (material != null) {
         	materialId = material.getId();
         } else {
-        	materialId = Integer.parseInt(map.get("name").toString()); // Non-existent (Forge) materials
-        }
+        	try {
+        		materialId = Integer.parseInt(map.get("name").toString()); // Non-existent (Forge) materials
+        	} catch(NumberFormatException e) {
+        		throw new IllegalArgumentException("Invalid reinforcement material.");
+        	}
+    	}
+    	
         
         strength = (Integer) map.get("strength");
         requirements = (Integer) map.get("requirements");
-        material = Material.getMaterial(map.get("flasher").toString());
+        
+        
+        material = Material.matchMaterial(map.get("flasher").toString());
         if (material != null) {
         	if(!material.isBlock()) {
         		throw new IllegalArgumentException("Supplied flasher value is a non-block material.");
         	}
         	flasherMaterialId = material.getId();
         } else {
-        	flasherMaterialId = Integer.parseInt((map.get("flasher").toString()));
-        }
+        	try {
+        		flasherMaterialId = Integer.parseInt((map.get("flasher").toString()));
+        	} catch(NumberFormatException e) {
+        		throw new IllegalArgumentException("Invalid flasher material.");
+        	}
+    	}
     }
 
     public ReinforcementMaterial(int materialId, int strength, int requirements, int flasherMaterialId) {

--- a/src/com/untamedears/citadel/entity/ReinforcementMaterial.java
+++ b/src/com/untamedears/citadel/entity/ReinforcementMaterial.java
@@ -37,18 +37,25 @@ public class ReinforcementMaterial implements Comparable<ReinforcementMaterial> 
     private int flasherMaterialId;
     
     public ReinforcementMaterial(LinkedHashMap map) {
-        Material material = Material.getMaterial((String) map.get("name"));
-        if (material == null) {
-            throw new IllegalArgumentException("Supplied name value is not a valid material.");
+        // Materials may be specified by name or by integer value
+    	Material material = Material.getMaterial(map.get("name").toString());
+        if (material != null) {
+        	materialId = material.getId();
+        } else {
+        	materialId = Integer.parseInt(map.get("name").toString()); // Non-existent (Forge) materials
         }
-        materialId = material.getId();
+        
         strength = (Integer) map.get("strength");
         requirements = (Integer) map.get("requirements");
-        material = Material.getMaterial((String) map.get("flasher"));
-        if (material == null || !material.isBlock()) {
-            throw new IllegalArgumentException("Supplied flasher value is not a valid block material.");
+        material = Material.getMaterial(map.get("flasher").toString());
+        if (material != null) {
+        	if(!material.isBlock()) {
+        		throw new IllegalArgumentException("Supplied flasher value is a non-block material.");
+        	}
+        	flasherMaterialId = material.getId();
+        } else {
+        	flasherMaterialId = Integer.parseInt((map.get("flasher").toString()));
         }
-        flasherMaterialId = material.getId();
     }
 
     public ReinforcementMaterial(int materialId, int strength, int requirements, int flasherMaterialId) {

--- a/src/com/untamedears/citadel/listener/BlockListener.java
+++ b/src/com/untamedears/citadel/listener/BlockListener.java
@@ -87,7 +87,18 @@ public class BlockListener implements Listener {
 
         AccessDelegate delegate = AccessDelegate.getDelegate(block);
         Reinforcement reinforcement = delegate.getReinforcement();
-        if (reinforcement == null) return;
+        if (reinforcement == null) {
+	    Material material = block.getType();
+	    int breakCount = Citadel.getConfigManager().getMaterialBreakCount(material.getId());
+	    if (breakCount <= 1) {
+	    	return;
+	    }
+            reinforcement = new Reinforcement(block, breakCount);
+            Citadel.getReinforcementManager().addReinforcement(reinforcement);
+            bbe.setCancelled(reinforcementDamaged(reinforcement));
+            block.getDrops().clear();
+	    return;
+	}
 
         PlayerState state = PlayerState.get(player);
         if (state.isBypassMode() && reinforcement.isBypassable(player)) {


### PR DESCRIPTION
Added the ability to configure reinforcement per material types for blocks
 generated across the map. This reinforcement is different than player
 reinforced blocks as it is done automatically in the DAO cache when a
 block of a configured material type is first broken. This type of
 reinforcement does NOT get saved to the database.

The configuration is simple:

```
  hardenedMaterials:
    IRON_ORE: 3
    DIAMOND_ORE: 10
```

This configuration would cause Iron Ore blocks to require breaking 3 times
 before they actually broke. As you can guess, the second material defined
 here would cause diamond ore to require 10 breaks.

I will add that the Reinforcement class should be refactored into
 IReinforcement, PlayerReinforcement, and EnvironmentalReinforcement so
 that this type of reinforcement, with how it is added here, isn't as
 kludgey in the code.

http://www.erocs.org/~erocs/Citadel_i71.jar
