### PR TITLE
Improved DAO stats + force cache flush + partial OptimisticLockException fix

### DIFF
--- a/src/com/untamedears/citadel/Citadel.java
+++ b/src/com/untamedears/citadel/Citadel.java
@@ -268,4 +268,8 @@ public class Citadel extends JavaPlugin {
         PlayerReinforcement pr = (PlayerReinforcement)reinforcement;
     	return pr.isAccessible(name);
     }
+
+    public static CitadelDao getDao() {
+        return (CitadelDao)dao;
+    }
 }

--- a/src/com/untamedears/citadel/Utility.java
+++ b/src/com/untamedears/citadel/Utility.java
@@ -112,6 +112,8 @@ public class Utility {
             	securityLevelText = securityLevelText + "-" + state.getFaction().getName();
             }
             sendThrottledMessage(player, ChatColor.GREEN, "Reinforced with %s at security level %s", material.getMaterial().name(), securityLevelText);
+            Citadel.warning(String.format("PlRein:%s:%d@%s,%d,%d,%d",
+                player.getName(), material.getMaterialId(), block.getWorld().getName(), block.getX(), block.getY(), block.getZ()));
             // TODO: enable chained flashers, they're pretty cool
             //new BlockFlasher(block, material.getFlasher()).start(getPlugin());
             //new BlockFlasher(block, material.getFlasher()).chain(securityMaterial.get(state.getSecurityLevel())).start();


### PR DESCRIPTION
This partially fixes the OptimisticLockException you were seeing. I did see it happen once more with this code though so I need to track down that edge case.

New console commands. Of interest "ctcon daocachestats" and "ctcon daocachestatsslow". The latter could be slow when there are large numbers of reinforcements cached so it has a separate command. Also "ctcon forcecacheflush" will flush 5 caches to the DB. You can add a parameter to change the count, like "ctcon forcecacheflush 100", but the higher the number the longer it could take.
