### PR TITLE
Change to speed up ctf use. Untested but small - never set up Bukkit.

### DIFF
--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -74,11 +74,21 @@ public class FortifyCommand extends PlayerCommand {
         if (securityLevel == null) return false;
 
         ReinforcementMaterial material = ReinforcementMaterial.get(player.getItemInHand().getType());
-        if (material == null) {
-            sendMessage(sender, ChatColor.YELLOW, "Invalid reinforcement material %s", player.getItemInHand().getType().name());
-        } else {
-            state.setFortificationMaterial(material);
+        if (state.getMode() == PlacementMode.FORTIFICATION) {
+            // Only change material if a valid reinforcement material in hand and not current reinforcement
+            if (material != null && material != state.getFortificationMaterial()) {
+                // Switch reinforcement materials without turning off and on again
+                state.reset();
+                state.setFortificationMaterial(material);
+            }
             setMultiMode(PlacementMode.FORTIFICATION, securityLevel, args, player, state);
+        } else {
+            if (material == null) {
+                sendMessage(sender, ChatColor.YELLOW, "Invalid reinforcement material %s", player.getItemInHand().getType().name());
+            } else {
+                state.setFortificationMaterial(material);
+                setMultiMode(PlacementMode.FORTIFICATION, securityLevel, args, player, state);
+            }
         }
         
         return true;

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -76,7 +76,7 @@ public class FortifyCommand extends PlayerCommand {
         ReinforcementMaterial material = ReinforcementMaterial.get(player.getItemInHand().getType());
         if (state.getMode() == PlacementMode.FORTIFICATION) {
             // Only change material if a valid reinforcement material in hand and not current reinforcement
-            if (material != null && material != state.getFortificationMaterial()) {
+            if (material != null && material != state.getReinforcementMaterial()) {
                 // Switch reinforcement materials without turning off and on again
                 state.reset();
                 state.setFortificationMaterial(material);


### PR DESCRIPTION
While doing a bunch of building in Civcraft I've been annoyed by a couple of little things with /ctf:
- You can't change reinforcement material without turning fortification mode off and on again.
- You can't change security level or leave fortification mode without holding the original material (or using /ctoff, which also messes up /ctbypass state).

I've added a condition that if you're already in fortification mode, /ctf will check these conditions:
- If holding a different, valid reinforcement material, will switch to that material without turning off fortification mode.
- If not holding a reinforcement material and selecting a different security level, will change security level and leave material as-is.
- If not holding a reinforcement material and using same security level, will turn off.

If not in fortification mode, behaves as it currently does.

I'm afraid I don't have a bukkit set-up to test this on sorry - hope worth your time to test. Please let me know if any issues with it.
