### PR TITLE
Change to speed up ctf use.

### DIFF
--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -44,14 +44,20 @@ public class FortifyCommand extends PlayerCommand {
 				groupName = args[1];
 			}
 		}
+		
 		if(secLevel != null && secLevel.equalsIgnoreCase("group")){
-			if(groupName == null || groupName.isEmpty() || groupName.equals("")){
-				sender.sendMessage(new StringBuilder().append("§cYou must specify a group in group fortification mode").toString());
-				sender.sendMessage(new StringBuilder().append("§cUsage:§e ").append("/ctfortify §8group <group-name>").toString());
-				return true;
-			}
-			GroupManager groupManager = Citadel.getGroupManager();
-			Faction group = groupManager.getGroup(groupName);
+                        Faction group;
+                        if(!(groupName == null) && !(groupName.isEmpty()) && !(groupName.equals(""))){
+                            GroupManager groupManager = Citadel.getGroupManager();
+                            group = groupManager.getGroup(groupName);
+                        } else if (state.getMode() == PlacementMode.FORTIFICATION && state.getSecurityLevel() == SecurityLevel.GROUP) {
+                            /* Default to current faction */
+                            group = state.getFaction();
+                        } else {
+                            sender.sendMessage(new StringBuilder().append("§cYou must specify a group in group fortification mode").toString());
+                            sender.sendMessage(new StringBuilder().append("§cUsage:§e ").append("/ctfortify §8group <group-name>").toString());
+                            return true;
+                        }
 			if(group == null){
 				sendMessage(sender, ChatColor.RED, "Group doesn't exist");
 				return true;

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -74,11 +74,21 @@ public class FortifyCommand extends PlayerCommand {
         if (securityLevel == null) return false;
 
         ReinforcementMaterial material = ReinforcementMaterial.get(player.getItemInHand().getType());
-        if (material == null) {
-            sendMessage(sender, ChatColor.YELLOW, "Invalid reinforcement material %s", player.getItemInHand().getType().name());
-        } else {
-            state.setFortificationMaterial(material);
+        if (state.getMode() == PlacementMode.FORTIFICATION) {
+            // Only change material if a valid reinforcement material in hand and not current reinforcement
+            if (material != null && material != state.getFortificationMaterial()) {
+                // Switch reinforcement materials without turning off and on again
+                state.reset();
+                state.setFortificationMaterial(material);
+            }
             setMultiMode(PlacementMode.FORTIFICATION, securityLevel, args, player, state);
+        } else {
+            if (material == null) {
+                sendMessage(sender, ChatColor.YELLOW, "Invalid reinforcement material %s", player.getItemInHand().getType().name());
+            } else {
+                state.setFortificationMaterial(material);
+                setMultiMode(PlacementMode.FORTIFICATION, securityLevel, args, player, state);
+            }
         }
         
         return true;

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -76,7 +76,7 @@ public class FortifyCommand extends PlayerCommand {
         ReinforcementMaterial material = ReinforcementMaterial.get(player.getItemInHand().getType());
         if (state.getMode() == PlacementMode.FORTIFICATION) {
             // Only change material if a valid reinforcement material in hand and not current reinforcement
-            if (material != null && material != state.getFortificationMaterial()) {
+            if (material != null && material != state.getReinforcementMaterial()) {
                 // Switch reinforcement materials without turning off and on again
                 state.reset();
                 state.setFortificationMaterial(material);

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -44,8 +44,14 @@ public class FortifyCommand extends PlayerCommand {
 				groupName = args[1];
 			}
 		}
+                
+                SecurityLevel securityLevel = getSecurityLevel(args, player);
+                if (securityLevel == null && state.getMode() == PlacementMode.FORTIFICATION) {
+                    securityLevel = state.getSecurityLevel();
+                }
+                if (securityLevel == null) return false;
 		
-		if(secLevel != null && secLevel.equalsIgnoreCase("group")){
+		if(securityLevel == SecurityLevel.GROUP){
                         Faction group;
                         if(!(groupName == null) && !(groupName.isEmpty()) && !(groupName.equals(""))){
                             GroupManager groupManager = Citadel.getGroupManager();
@@ -75,9 +81,6 @@ public class FortifyCommand extends PlayerCommand {
 		} else {
 			state.setFaction(Citadel.getMemberManager().getMember(player).getPersonalGroup());
 		}
-		
-		SecurityLevel securityLevel = getSecurityLevel(args, player);
-        if (securityLevel == null) return false;
 
         ReinforcementMaterial material = ReinforcementMaterial.get(player.getItemInHand().getType());
         if (state.getMode() == PlacementMode.FORTIFICATION) {

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -46,7 +46,7 @@ public class FortifyCommand extends PlayerCommand {
 		}
                 
                 SecurityLevel securityLevel = getSecurityLevel(args, player);
-                if (securityLevel == null && state.getMode() == PlacementMode.FORTIFICATION) {
+                if (secLevel == null && state.getMode() == PlacementMode.FORTIFICATION) {
                     securityLevel = state.getSecurityLevel();
                 }
                 if (securityLevel == null) return false;

--- a/src/com/untamedears/citadel/command/commands/FortifyCommand.java
+++ b/src/com/untamedears/citadel/command/commands/FortifyCommand.java
@@ -46,7 +46,7 @@ public class FortifyCommand extends PlayerCommand {
 		}
                 
                 SecurityLevel securityLevel = getSecurityLevel(args, player);
-                if (secLevel == null && state.getMode() == PlacementMode.FORTIFICATION) {
+                if ((secLevel == null || secLevel.isEmpty()) && state.getMode() == PlacementMode.FORTIFICATION) {
                     securityLevel = state.getSecurityLevel();
                 }
                 if (securityLevel == null) return false;


### PR DESCRIPTION
This is a fixed version of pull request https://github.com/Exultant/Citadel/pull/93 .

I've managed to compile it with Maven (though produced jar doesn't have the plugin.xml and such?). In doing so found that I had a method name wrong. Compiles but haven't managed to run.

EDIT: now run and tested. That was much easier than expected...

Original message:

While doing a bunch of building in Civcraft I've been annoyed by a couple of little things with /ctf:
- You can't change reinforcement material without turning fortification mode off and on again.
- You can't change security level or leave fortification mode without holding the original material (or using /ctoff, which also messes up /ctbypass state).

I've added a condition that if you're already in fortification mode, /ctf will check these conditions:
- If holding a different, valid reinforcement material, will switch to that material without turning off fortification mode.
- If not holding a reinforcement material and selecting a different security level, will change security level and leave material as-is.
- If not holding a reinforcement material and using same security level, will turn off.

If not in fortification mode, behaves as it currently does.

I'm afraid I don't have a bukkit set-up to test this on sorry - hope worth your time to test. Please let me know if any issues with it.
