### PR TITLE
Non-persistent durability for natural reinforcement

### DIFF
--- a/src/com/untamedears/citadel/Utility.java
+++ b/src/com/untamedears/citadel/Utility.java
@@ -196,9 +196,9 @@ public class Utility {
     }
 
     public static boolean reinforcementDamaged(IReinforcement reinforcement) {
-        reinforcement.setDurability(reinforcement.getDurability() - 1);
-        boolean cancelled = reinforcement.getDurability() > 0;
-        if (reinforcement.getDurability() <= 0) {
+        boolean isBroken = reinforcement.breakOnce();
+        boolean cancelled = !isBroken;
+        if (!cancelled) {
             cancelled = reinforcementBroken(reinforcement);
         } else {
             if (reinforcement instanceof PlayerReinforcement) {

--- a/src/com/untamedears/citadel/dao/CitadelCachingDao.java
+++ b/src/com/untamedears/citadel/dao/CitadelCachingDao.java
@@ -345,7 +345,7 @@ public class CitadelCachingDao extends CitadelDao {
         }
 
         public IReinforcement save( IReinforcement r ){
-            if (r.getDurability() <= 0)
+            if (r.isBroken())
             {
                 delete(r);
                 return null;

--- a/src/com/untamedears/citadel/entity/IReinforcement.java
+++ b/src/com/untamedears/citadel/entity/IReinforcement.java
@@ -7,9 +7,9 @@ public abstract interface IReinforcement extends
     public ReinforcementKey getId();
     public void setId(ReinforcementKey id);
     public Block getBlock();
-    public int getDurability();
-    public void setDurability(int durability);
     public double getHealth();
     public String getHealthText();
     public String getStatus();
+    public boolean isBroken();
+    public boolean breakOnce();
 }

--- a/src/com/untamedears/citadel/entity/NaturalReinforcement.java
+++ b/src/com/untamedears/citadel/entity/NaturalReinforcement.java
@@ -1,6 +1,7 @@
 package com.untamedears.citadel.entity;
 
 import java.util.HashMap;
+import java.util.Random;
 
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
@@ -16,15 +17,18 @@ public class NaturalReinforcement implements IReinforcement {
         new HashMap<Integer, NaturalReinforcementConfig>();
 
     private ReinforcementKey id_;
-    private int durability_;
+    private boolean broken_;
     private int max_durability_;
+    private Random random;
 
-    public NaturalReinforcement() {}
+    public NaturalReinforcement() {
+        this.random = new Random();
+    }
 
-    public NaturalReinforcement(Block block, int breakCount) {
+    public NaturalReinforcement(Block block, int max_durability) {
         this.id_ = new ReinforcementKey(block);
-        this.durability_ = breakCount;
-        this.max_durability_ = breakCount;
+        this.max_durability_ = max_durability;
+        this.random = new Random();
     }
 
     public ReinforcementKey getId() { return id_; }
@@ -41,34 +45,22 @@ public class NaturalReinforcement implements IReinforcement {
         }
     }
 
-    public int getDurability() { return durability_; }
-    public void setDurability(int durability) { durability_ = durability; }
-
     public int getMaxDurability() { return max_durability_; }
     public void setMaxDurability(int max_durability) { this.max_durability_ = max_durability; }
 
     public double getHealth() {
-        return (double) durability_ / (double) max_durability_;
+        return 1.0;
     }
 
     public String getHealthText() {
-        double health = getHealth();
-        if (health > 0.75) {
-            return "excellently";
-        } else if (health > 0.50) {
-            return "well";
-        } else if (health > 0.25) {
-            return "decently";
-        } else {
-            return "poorly";
-        }
+        return "naturally";
     }
 
     public String getStatus() { return getHealthText(); }
 
     @Override
     public String toString() {
-        return String.format("%s, durability: %d of %d", id_, durability_, max_durability_);
+        return String.format("%s, hardness %d", id_, max_durability_);
     }
 
     @Override
@@ -87,5 +79,19 @@ public class NaturalReinforcement implements IReinforcement {
     @Override
     public int hashCode() {
         return this.id_.hashCode();
+    }
+    
+    @Override
+    public boolean isBroken() {
+        return broken_;
+    }
+    
+    @Override
+    public boolean breakOnce() {
+        if (broken_) return true;
+        if (random.nextInt(max_durability_) == 0) {
+          broken_ = true;
+        }
+        return broken_;
     }
 }

--- a/src/com/untamedears/citadel/entity/PlayerReinforcement.java
+++ b/src/com/untamedears/citadel/entity/PlayerReinforcement.java
@@ -253,6 +253,19 @@ public class PlayerReinforcement implements
         return this.id.hashCode();
     }
 
+    @Override
+    public boolean isBroken() {
+        return this.durability <= 0;
+    }
+
+    @Override
+    public boolean breakOnce() {
+        if (!isBroken()) {
+          this.durability--;
+        }
+        return isBroken();
+    }
+
     public DbUpdateAction getDbAction() { return this.dbAction; }
     public void setDbAction(DbUpdateAction value) { this.dbAction = value; }
 }


### PR DESCRIPTION
This is the first in a series of changes to make breaking naturally reinforced resources less "grindy" and make this mechanic more acceptable to a wider group of players. It also makes natural reinforcements not being saved less of an issue.

This changes the natural reinforcement mechanics so that rather than taking a fixed number of hits, it has a random chance to break on each hit. This fits in better with the reinforcements not being saved - instead of the count resetting to maximum if the cache is unloaded you have a continuous probability of the block breaking on each hit.

The probability is 1.0 / durability. If you set the durability to 50, there's a 1/50 chance of it breaking on each hit. It could take 1, it could take forever, but on average will take 50 breaks. Failed breaks don't weaken or reduce its reinforcement, making the non-saving of natural reinforcements not a problem.

I have plans to add support for "chips" in another pull - random drops from naturally reinforced blocks. For example, a diamond ore could have a high durability, small chance of dropping extra diamonds on each failed break. It would produce several diamonds before finally breaking (balanced with rarity and durability). This requires (a) this change to avoid resetting durability for unlimited d and (b) ability to disable getting chips with silk touch tools.
