### PR TITLE
Chips

### DIFF
--- a/src/com/untamedears/citadel/Utility.java
+++ b/src/com/untamedears/citadel/Utility.java
@@ -196,9 +196,9 @@ public class Utility {
     }
 
     public static boolean reinforcementDamaged(IReinforcement reinforcement) {
-        reinforcement.setDurability(reinforcement.getDurability() - 1);
-        boolean cancelled = reinforcement.getDurability() > 0;
-        if (reinforcement.getDurability() <= 0) {
+        boolean isBroken = reinforcement.breakOnce();
+        boolean cancelled = !isBroken;
+        if (!cancelled) {
             cancelled = reinforcementBroken(reinforcement);
         } else {
             if (reinforcement instanceof PlayerReinforcement) {

--- a/src/com/untamedears/citadel/dao/CitadelCachingDao.java
+++ b/src/com/untamedears/citadel/dao/CitadelCachingDao.java
@@ -345,7 +345,7 @@ public class CitadelCachingDao extends CitadelDao {
         }
 
         public IReinforcement save( IReinforcement r ){
-            if (r.getDurability() <= 0)
+            if (r.isBroken())
             {
                 delete(r);
                 return null;

--- a/src/com/untamedears/citadel/entity/IReinforcement.java
+++ b/src/com/untamedears/citadel/entity/IReinforcement.java
@@ -7,9 +7,9 @@ public abstract interface IReinforcement extends
     public ReinforcementKey getId();
     public void setId(ReinforcementKey id);
     public Block getBlock();
-    public int getDurability();
-    public void setDurability(int durability);
     public double getHealth();
     public String getHealthText();
     public String getStatus();
+    public boolean isBroken();
+    public boolean breakOnce();
 }

--- a/src/com/untamedears/citadel/entity/NaturalReinforcement.java
+++ b/src/com/untamedears/citadel/entity/NaturalReinforcement.java
@@ -1,6 +1,7 @@
 package com.untamedears.citadel.entity;
 
 import java.util.HashMap;
+import java.util.Random;
 
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
@@ -16,15 +17,18 @@ public class NaturalReinforcement implements IReinforcement {
         new HashMap<Integer, NaturalReinforcementConfig>();
 
     private ReinforcementKey id_;
-    private int durability_;
+    private boolean broken_;
     private int max_durability_;
+    private Random random;
 
-    public NaturalReinforcement() {}
+    public NaturalReinforcement() {
+        this.random = new Random();
+    }
 
-    public NaturalReinforcement(Block block, int breakCount) {
+    public NaturalReinforcement(Block block, int max_durability) {
         this.id_ = new ReinforcementKey(block);
-        this.durability_ = breakCount;
-        this.max_durability_ = breakCount;
+        this.max_durability_ = max_durability;
+        this.random = new Random();
     }
 
     public ReinforcementKey getId() { return id_; }
@@ -41,34 +45,22 @@ public class NaturalReinforcement implements IReinforcement {
         }
     }
 
-    public int getDurability() { return durability_; }
-    public void setDurability(int durability) { durability_ = durability; }
-
     public int getMaxDurability() { return max_durability_; }
     public void setMaxDurability(int max_durability) { this.max_durability_ = max_durability; }
 
     public double getHealth() {
-        return (double) durability_ / (double) max_durability_;
+        return 1.0;
     }
 
     public String getHealthText() {
-        double health = getHealth();
-        if (health > 0.75) {
-            return "excellently";
-        } else if (health > 0.50) {
-            return "well";
-        } else if (health > 0.25) {
-            return "decently";
-        } else {
-            return "poorly";
-        }
+        return "naturally";
     }
 
     public String getStatus() { return getHealthText(); }
 
     @Override
     public String toString() {
-        return String.format("%s, durability: %d of %d", id_, durability_, max_durability_);
+        return String.format("%s, hardness %d", id_, max_durability_);
     }
 
     @Override
@@ -87,5 +79,19 @@ public class NaturalReinforcement implements IReinforcement {
     @Override
     public int hashCode() {
         return this.id_.hashCode();
+    }
+    
+    @Override
+    public boolean isBroken() {
+        return broken_;
+    }
+    
+    @Override
+    public boolean breakOnce() {
+        if (broken_) return true;
+        if (random.nextInt(max_durability_) == 0) {
+          broken_ = true;
+        }
+        return broken_;
     }
 }

--- a/src/com/untamedears/citadel/entity/NaturalReinforcement.java
+++ b/src/com/untamedears/citadel/entity/NaturalReinforcement.java
@@ -2,8 +2,12 @@ package com.untamedears.citadel.entity;
 
 import java.util.HashMap;
 import java.util.Random;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.block.Block;
 
 import com.untamedears.citadel.NaturalReinforcementConfig;
@@ -93,5 +97,23 @@ public class NaturalReinforcement implements IReinforcement {
           broken_ = true;
         }
         return broken_;
+    }
+    
+    public List<ItemStack> generateChipDrops() {
+        List<ItemStack> result = new ArrayList<ItemStack>();
+        NaturalReinforcementConfig config = getConfig();
+        if (config == null) {
+            return null;
+        }
+        
+        Material mat = getConfig().generateChipDrop(random);
+        if (mat != null) {
+            result.add(new ItemStack(mat, 1));
+        }
+        return result;
+    }
+    
+    public NaturalReinforcementConfig getConfig() {
+        return NaturalReinforcement.CONFIGURATION.get(getBlock().getTypeId());
     }
 }

--- a/src/com/untamedears/citadel/entity/PlayerReinforcement.java
+++ b/src/com/untamedears/citadel/entity/PlayerReinforcement.java
@@ -253,6 +253,19 @@ public class PlayerReinforcement implements
         return this.id.hashCode();
     }
 
+    @Override
+    public boolean isBroken() {
+        return this.durability <= 0;
+    }
+
+    @Override
+    public boolean breakOnce() {
+        if (!isBroken()) {
+          this.durability--;
+        }
+        return isBroken();
+    }
+
     public DbUpdateAction getDbAction() { return this.dbAction; }
     public void setDbAction(DbUpdateAction value) { this.dbAction = value; }
 }

--- a/src/com/untamedears/citadel/listener/BlockListener.java
+++ b/src/com/untamedears/citadel/listener/BlockListener.java
@@ -129,6 +129,12 @@ public class BlockListener implements Listener {
                 if (is_cancelled) {
                     // Drop chips if not using silk touch
                     extraDrops = natural.generateChipDrops();
+                    if (extraDrops.size() > 0) {
+                        tool.setDurability((short) (tool.getDurability() + 1));
+                        if (tool.getDurability() >= tool.getType().getMaxDurability()) {
+                            player.setItemInHand(null);
+                        }
+                    }
                 } else {
                     // Block drops if told to and not using silk touch
                     if (natural.getConfig().getDisableNormalDrops()) {

--- a/src/com/untamedears/citadel/listener/BlockListener.java
+++ b/src/com/untamedears/citadel/listener/BlockListener.java
@@ -10,6 +10,7 @@ import static com.untamedears.citadel.Utility.sendMessage;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -28,6 +29,7 @@ import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.BlockRedstoneEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.material.MaterialData;
@@ -88,6 +90,7 @@ public class BlockListener implements Listener {
     public void blockBreak(BlockBreakEvent bbe) {
         Block block = bbe.getBlock();
         Player player = bbe.getPlayer();
+        List<ItemStack> extraDrops = null;
 
         AccessDelegate delegate = AccessDelegate.getDelegate(block);
         IReinforcement reinforcement = delegate.getReinforcement();
@@ -115,6 +118,25 @@ public class BlockListener implements Listener {
                 // The player reinforcement broke. Now check for natural
                 is_cancelled = createNaturalReinforcement(block) != null;
             }
+        } else if (reinforcement instanceof NaturalReinforcement) {
+            NaturalReinforcement natural = (NaturalReinforcement) reinforcement;
+            is_cancelled = reinforcementDamaged(reinforcement);
+            
+            // Check for silk touch and bypass all chip behaviour to avoid infinite mining
+            ItemStack tool = player.getItemInHand();
+            boolean silkTouch = tool.containsEnchantment(Enchantment.SILK_TOUCH);
+            if (!silkTouch) {
+                if (is_cancelled) {
+                    // Drop chips if not using silk touch
+                    extraDrops = natural.generateChipDrops();
+                } else {
+                    // Block drops if told to and not using silk touch
+                    if (natural.getConfig().getDisableNormalDrops()) {
+                        bbe.setCancelled(true);
+                        block.setType(Material.AIR);
+                    }
+                }
+            }
         } else {
             is_cancelled = reinforcementDamaged(reinforcement);
         }
@@ -122,6 +144,18 @@ public class BlockListener implements Listener {
         if (is_cancelled) {
             bbe.setCancelled(true);
             block.getDrops().clear();
+        }
+        
+        if (extraDrops != null) {
+            Location centerOfBlock = block.getLocation().add(0.5, 0.5, 0.5);
+            Location playerHeadLocation = player.getLocation().add(0, 1, 0);
+            Location difference = playerHeadLocation.subtract(centerOfBlock);
+            // Drop 1 block in direction of player's head
+            Location dropPosition = centerOfBlock.add(difference.multiply(1.0 / difference.length()));
+            
+            for (ItemStack drop : extraDrops) {
+                block.getWorld().dropItemNaturally(dropPosition, drop);
+            }
         }
     }
 


### PR DESCRIPTION
This includes my last pull request as well as it has a dependency on it.

This provides the ability to make naturally reinforced blocks drop "chips" while we mine them. These are an item that drops with some probability on each blocked break. It also includes an ability to block the final drop.

Here's an example natural reinforcements section of config:

```
naturalReinforcements:
  STONE:
    durability: 5
  IRON_ORE:
    durability: 50
    chipDrops:
      IRON_INGOT: 0.1
    disableNormalDrops: true
```

This would make stone take on average 5 breaks to break and iron ore 50. The iron ore, however, would not drop ore as normal. It would instead have a 10% (0.1) chance of dropping an iron ingot on each break, making each ore give us on average 5 ingots. When it finally breaks we get nothing due to disableNormalDrops being set for IRON_ORE.

Note that all this logic is disabled if a silk touch tool is used. Mining with ST never drops chips, but the final drop is allowed (so ores can be collected). We could collect the iron ore by breaking it with ST (still average 50 hits) but would not get chips while doing so. This prevents us from placing the iron ore and starting to mine it again.
